### PR TITLE
Add player counting example with YOLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# fifa_analyzer
-fifa_analyzer
+# FIFA Analyzer
+
+This repository demonstrates counting the number of players in each frame of an EA25 gameplay video using OpenCV and a pretrained YOLOv8 model.
+
+## Setup
+
+Install dependencies with pip:
+
+```bash
+pip install opencv-python-headless ultralytics
+```
+
+## Usage
+
+Run the `count_players.py` script with the path to your gameplay video. You can
+optionally specify a custom YOLOv8 weight file using `--model`:
+
+```bash
+python count_players.py /path/to/ea25_gameplay.mp4 --model yolov8n.pt
+```
+
+The script prints the detected number of players for every frame.

--- a/count_players.py
+++ b/count_players.py
@@ -1,0 +1,47 @@
+import argparse
+import cv2
+from ultralytics import YOLO
+
+
+def count_players(video_path, model_path="yolov8n.pt"):
+    """Print the number of detected players for every frame in the video.
+
+    Parameters
+    ----------
+    video_path : str
+        Path to the gameplay video file.
+    model_path : str, optional
+        Path to a YOLOv8 model weight file. ``yolov8n.pt`` is used by default.
+    """
+
+    model = YOLO(model_path)
+    cap = cv2.VideoCapture(video_path)
+    frame_idx = 0
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        results = model(frame, verbose=False)[0]
+        person_idx = 0  # COCO class index for 'person'
+        num_players = int((results.boxes.cls == person_idx).sum())
+        print(f"Frame {frame_idx}: {num_players} players detected")
+        frame_idx += 1
+    cap.release()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Count players in each frame of gameplay video using YOLO"
+    )
+    parser.add_argument("video", help="Path to EA25 gameplay video file")
+    parser.add_argument(
+        "--model",
+        default="yolov8n.pt",
+        help="Path to YOLOv8 weights (default: yolov8n.pt)",
+    )
+    args = parser.parse_args()
+    count_players(args.video, args.model)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `count_players.py` script showing how to count players per frame using cv2 and YOLO
- update README with setup and usage instructions
- added optional argument for specifying YOLO weight file

## Testing
- `python count_players.py -h` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_6854576604808325a3fcbbf8e3b1f502