### PR TITLE
Enhance player counting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ pip install -r requirements.txt
 
 ## Usage
 
-Run the `count_players.py` script with the path to your gameplay video. You can
-optionally specify a custom YOLOv8 weight file using `--model`:
+Run the `count_players.py` script and follow the prompts to provide the video
+path and optional settings. You can specify a custom YOLOv8 weight file, choose
+to display the annotated frames, and optionally save the result:
 
 ```bash
-python count_players.py /path/to/ea25_gameplay.mp4 --model yolov8n.pt
+python count_players.py
 ```
 
-The script prints the detected number of players for every frame.
+After running the command, enter the requested parameters when prompted. The
+script prints the detected number of players for every frame.

--- a/count_players.py
+++ b/count_players.py
@@ -1,9 +1,8 @@
-import argparse
 import cv2
 from ultralytics import YOLO
 
 
-def count_players(video_path, model_path="yolov8n.pt"):
+def count_players(video_path, model_path="yolov8n.pt", show=False, output=None):
     """Print the number of detected players for every frame in the video.
 
     Parameters
@@ -12,10 +11,21 @@ def count_players(video_path, model_path="yolov8n.pt"):
         Path to the gameplay video file.
     model_path : str, optional
         Path to a YOLOv8 model weight file. ``yolov8n.pt`` is used by default.
+    show : bool, optional
+        If ``True``, display the annotated video frames.
+    output : str, optional
+        If provided, save the annotated video to this path.
     """
 
     model = YOLO(model_path)
     cap = cv2.VideoCapture(video_path)
+    writer = None
+    if output:
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        fps = cap.get(cv2.CAP_PROP_FPS) or 30
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        writer = cv2.VideoWriter(output, fourcc, fps, (width, height))
     frame_idx = 0
     while True:
         ret, frame = cap.read()
@@ -23,24 +33,44 @@ def count_players(video_path, model_path="yolov8n.pt"):
             break
         results = model(frame, verbose=False)[0]
         person_idx = 0  # COCO class index for 'person'
-        num_players = int((results.boxes.cls == person_idx).sum())
+        mask = results.boxes.cls == person_idx
+        num_players = int(mask.sum())
+        boxes = results.boxes.xyxy[mask].cpu().numpy().astype(int)
+        for x1, y1, x2, y2 in boxes:
+            cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        cv2.putText(
+            frame,
+            f"Players: {num_players}",
+            (10, 30),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1,
+            (0, 255, 0),
+            2,
+        )
         print(f"Frame {frame_idx}: {num_players} players detected")
+        if show:
+            cv2.imshow("FIFA Analyzer", frame)
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                break
+        if writer:
+            writer.write(frame)
         frame_idx += 1
     cap.release()
+    if writer:
+        writer.release()
+    if show:
+        cv2.destroyAllWindows()
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Count players in each frame of gameplay video using YOLO"
-    )
-    parser.add_argument("video", help="Path to EA25 gameplay video file")
-    parser.add_argument(
-        "--model",
-        default="yolov8n.pt",
-        help="Path to YOLOv8 weights (default: yolov8n.pt)",
-    )
-    args = parser.parse_args()
-    count_players(args.video, args.model)
+    """Prompt for parameters and run player counting."""
+    video_path = input("Path to EA25 gameplay video file: ")
+    model_path = input("Path to YOLOv8 weights [yolov8n.pt]: ") or "yolov8n.pt"
+    show = input("Display annotated frames? [y/N]: ").strip().lower() == "y"
+    output = input(
+        "Optional path to save the annotated video (leave blank to skip): "
+    ).strip() or None
+    count_players(video_path, model_path, show, output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- visualize detections while counting players
- allow saving the annotated video
- document new options in README
- prompt for player counting parameters interactively

## Testing
- `python -m py_compile count_players.py`

------
https://chatgpt.com/codex/tasks/task_e_68591a3237488325928b7b69ae55b7e4